### PR TITLE
Add logout action in IT so that each test can return to its original state

### DIFF
--- a/lib/ui/app/app_drawer.dart
+++ b/lib/ui/app/app_drawer.dart
@@ -271,6 +271,7 @@ class AppDrawer extends StatelessWidget {
           ),
 
           DrawerTile(
+            key: Key(SettingsKeys.drawer),
             company: company,
             icon: FontAwesomeIcons.cog,
             title: localization.settings,

--- a/lib/utils/keys.dart
+++ b/lib/utils/keys.dart
@@ -28,3 +28,7 @@ class ProductKeys {
   static const String cost = 'productCost';
   static const String filter = 'productFilter';
 }
+
+class SettingsKeys {
+  static const String drawer = 'settingsDrawer';
+}

--- a/test_driver/login_it_test.dart
+++ b/test_driver/login_it_test.dart
@@ -44,6 +44,10 @@ void main() {
           timeout: new Duration(seconds: 60),
         );
       });
+
+      test('Logout from a logged in user', () async {
+        await logout(driver, localization);
+      });
     });
   });
 }

--- a/test_driver/products_it_test.dart
+++ b/test_driver/products_it_test.dart
@@ -53,7 +53,7 @@ void main() {
 
       await driver.tap(find.pageBack());
 
-      //TODO: This will not work if the product is out of the scrollable view
+      await driver.scrollUntilVisible(find.byType('ListView'), find.text(productKey));
       await driver.tap(find.text(productKey));
       await driver.waitFor(find.text(productKey));
       await driver.waitFor(find.text(notes));
@@ -65,7 +65,7 @@ void main() {
 
     // Edit the newly created product
     test('Edit an existing product', () async {
-      //TODO: This will not work if the product is out of the scrollable view
+      await driver.scrollUntilVisible(find.byType('ListView'), find.text(productKey));
       await driver.tap(find.text(productKey), timeout: Duration(seconds: 3));
 
       await driver.tap(find.byValueKey(ProductKeys.productKey));

--- a/test_driver/products_it_test.dart
+++ b/test_driver/products_it_test.dart
@@ -36,6 +36,17 @@ void main() {
       }
     });
 
+    // Create an empty product
+    test('Try to add an empty product', () async {
+      await driver.tap(find.byValueKey(ProductKeys.fab));
+
+      await driver.tap(find.byTooltip(localization.save));
+
+      await driver.waitFor(find.text(localization.pleaseEnterAProductKey));
+
+      await driver.tap(find.pageBack());
+    });
+
     // Create a new product
     test('Add a new product', () async {
       await driver.tap(find.byValueKey(ProductKeys.fab));

--- a/test_driver/products_it_test.dart
+++ b/test_driver/products_it_test.dart
@@ -29,6 +29,8 @@ void main() {
     });
 
     tearDownAll(() async {
+      await logout(driver, localization);
+
       if (driver != null) {
         driver.close();
       }

--- a/test_driver/utils/common_actions.dart
+++ b/test_driver/utils/common_actions.dart
@@ -2,6 +2,8 @@ import 'package:flutter_driver/flutter_driver.dart';
 import 'package:invoiceninja_flutter/.env.dart';
 import 'package:invoiceninja_flutter/utils/keys.dart';
 
+import 'localizations.dart';
+
 Future<void> login(FlutterDriver driver,
   {
     bool selfHosted = true,
@@ -28,6 +30,23 @@ Future<void> login(FlutterDriver driver,
   }
 
   await driver.tap(find.text(LoginKeys.loginButton.toUpperCase()));
+}
+
+Future<void> logout(FlutterDriver driver, TestLocalization localization) async {
+  // Go to Settings Screen
+  await driver.tap(find.byTooltip(AppKeys.openAppDrawer));
+  await driver.scrollUntilVisible(find.byType('Drawer'), find.byValueKey(SettingsKeys.drawer));
+  await driver.tap(find.byValueKey(SettingsKeys.drawer));
+
+  // Tap on Log Out
+  await driver.tap(find.text(localization.logout));
+
+  // Confirm log out
+  await driver.waitFor(find.text(localization.areYouSure));
+  await driver.tap(find.text(localization.ok.toUpperCase()));
+
+  // Should be in the login screen now
+  await driver.waitFor(find.text(localization.login.toUpperCase()));
 }
 
 Future<void> loginAndOpenProducts(FlutterDriver driver) async {


### PR DESCRIPTION
I realized that running `products_it_test` after `login_it_test` will try to `loginAndOpenProducts`, but as we are already logged in (cause login_it_test has already run).

I introduce the `logout` action so each IT can return to its original logged out state.