### PR TITLE
Fixes in Multiselect logic

### DIFF
--- a/lib/redux/client/client_actions.dart
+++ b/lib/redux/client/client_actions.dart
@@ -322,7 +322,7 @@ void handleClientAction(
       break;
     case EntityAction.toggleMultiselect:
       if (!store.state.clientListState.isInMultiselect()) {
-        store.dispatch(StartMultiselect(context: context));
+        store.dispatch(StartClientMultiselect(context: context));
       }
 
       if (clients.isEmpty) {
@@ -331,38 +331,38 @@ void handleClientAction(
 
       for (final client in clients) {
         if (!state.clientListState.isSelected(client)) {
-          store.dispatch(AddToMultiselect(context: context, entity: client));
+          store.dispatch(AddToClientMultiselect(context: context, entity: client));
         } else {
           store.dispatch(
-              RemoveFromMultiselect(context: context, entity: client));
+              RemoveFromClientMultiselect(context: context, entity: client));
         }
       }
       break;
   }
 }
 
-class StartMultiselect {
-  StartMultiselect({@required this.context});
+class StartClientMultiselect {
+  StartClientMultiselect({@required this.context});
 
   final BuildContext context;
 }
 
-class AddToMultiselect {
-  AddToMultiselect({@required this.context, @required this.entity});
-
-  final BuildContext context;
-  final BaseEntity entity;
-}
-
-class RemoveFromMultiselect {
-  RemoveFromMultiselect({@required this.context, @required this.entity});
+class AddToClientMultiselect {
+  AddToClientMultiselect({@required this.context, @required this.entity});
 
   final BuildContext context;
   final BaseEntity entity;
 }
 
-class ClearMultiselect {
-  ClearMultiselect({@required this.context});
+class RemoveFromClientMultiselect {
+  RemoveFromClientMultiselect({@required this.context, @required this.entity});
+
+  final BuildContext context;
+  final BaseEntity entity;
+}
+
+class ClearClientMultiselect {
+  ClearClientMultiselect({@required this.context});
 
   final BuildContext context;
 }

--- a/lib/redux/client/client_actions.dart
+++ b/lib/redux/client/client_actions.dart
@@ -271,8 +271,12 @@ class FilterClientsByCustom2 implements PersistUI {
 void handleClientAction(
     BuildContext context, List<ClientEntity> clients, EntityAction action) {
   assert(
-      [EntityAction.restore, EntityAction.archive, EntityAction.delete]
-              .contains(action) ||
+      [
+            EntityAction.restore,
+            EntityAction.archive,
+            EntityAction.delete,
+            EntityAction.toggleMultiselect
+          ].contains(action) ||
           clients.length == 1,
       'Cannot perform this action on more than one client');
   final store = StoreProvider.of<AppState>(context);
@@ -325,9 +329,8 @@ void handleClientAction(
         break;
       }
 
-      final select = !store.state.clientListState.isSelected(client);
       for (final client in clients) {
-        if (select) {
+        if (!state.clientListState.isSelected(client)) {
           store.dispatch(AddToMultiselect(context: context, entity: client));
         } else {
           store.dispatch(

--- a/lib/redux/client/client_reducer.dart
+++ b/lib/redux/client/client_reducer.dart
@@ -105,10 +105,10 @@ final clientListReducer = combineReducers<ListUIState>([
   TypedReducer<ListUIState, FilterClientsByEntity>(_filterClientsByEntity),
   TypedReducer<ListUIState, FilterClientsByCustom1>(_filterClientsByCustom1),
   TypedReducer<ListUIState, FilterClientsByCustom2>(_filterClientsByCustom2),
-  TypedReducer<ListUIState, StartMultiselect>(_startListMultiselect),
-  TypedReducer<ListUIState, AddToMultiselect>(_addToListMultiselect),
-  TypedReducer<ListUIState, RemoveFromMultiselect>(_removeFromListMultiselect),
-  TypedReducer<ListUIState, ClearMultiselect>(_clearListMultiselect),
+  TypedReducer<ListUIState, StartClientMultiselect>(_startListMultiselect),
+  TypedReducer<ListUIState, AddToClientMultiselect>(_addToListMultiselect),
+  TypedReducer<ListUIState, RemoveFromClientMultiselect>(_removeFromListMultiselect),
+  TypedReducer<ListUIState, ClearClientMultiselect>(_clearListMultiselect),
 ]);
 
 ListUIState _filterClientsByCustom1(
@@ -162,23 +162,23 @@ ListUIState _sortClients(ListUIState clientListState, SortClients action) {
 }
 
 ListUIState _startListMultiselect(
-    ListUIState clientListState, StartMultiselect action) {
+    ListUIState clientListState, StartClientMultiselect action) {
   return clientListState.rebuild((b) => b..selectedEntities = <BaseEntity>[]);
 }
 
 ListUIState _addToListMultiselect(
-    ListUIState clientListState, AddToMultiselect action) {
+    ListUIState clientListState, AddToClientMultiselect action) {
   return clientListState.rebuild((b) => b..selectedEntities.add(action.entity));
 }
 
 ListUIState _removeFromListMultiselect(
-    ListUIState clientListState, RemoveFromMultiselect action) {
+    ListUIState clientListState, RemoveFromClientMultiselect action) {
   return clientListState
       .rebuild((b) => b..selectedEntities.remove(action.entity));
 }
 
 ListUIState _clearListMultiselect(
-    ListUIState clientListState, ClearMultiselect action) {
+    ListUIState clientListState, ClearClientMultiselect action) {
   return clientListState.rebuild((b) => b..selectedEntities = null);
 }
 

--- a/lib/redux/product/product_actions.dart
+++ b/lib/redux/product/product_actions.dart
@@ -198,8 +198,12 @@ class FilterProductDropdown {
 void handleProductAction(
     BuildContext context, List<BaseEntity> products, EntityAction action) {
   assert(
-      [EntityAction.restore, EntityAction.archive, EntityAction.delete]
-              .contains(action) ||
+      [
+            EntityAction.restore,
+            EntityAction.archive,
+            EntityAction.delete,
+            EntityAction.toggleMultiselect
+          ].contains(action) ||
           products.length == 1,
       'Cannot perform this action on more than one product');
   final store = StoreProvider.of<AppState>(context);
@@ -246,9 +250,8 @@ void handleProductAction(
         break;
       }
 
-      final select = !store.state.productListState.isSelected(product);
       for (final product in products) {
-        if (select) {
+        if (!store.state.productListState.isSelected(product)) {
           store.dispatch(AddToMultiselect(context: context, entity: product));
         } else {
           store.dispatch(

--- a/lib/redux/product/product_actions.dart
+++ b/lib/redux/product/product_actions.dart
@@ -243,7 +243,7 @@ void handleProductAction(
       break;
     case EntityAction.toggleMultiselect:
       if (!store.state.productListState.isInMultiselect()) {
-        store.dispatch(StartMultiselect(context: context));
+        store.dispatch(StartProductMultiselect(context: context));
       }
 
       if (products.isEmpty) {
@@ -252,38 +252,39 @@ void handleProductAction(
 
       for (final product in products) {
         if (!store.state.productListState.isSelected(product)) {
-          store.dispatch(AddToMultiselect(context: context, entity: product));
+          store.dispatch(
+              AddToProductMultiselect(context: context, entity: product));
         } else {
           store.dispatch(
-              RemoveFromMultiselect(context: context, entity: product));
+              RemoveFromProductMultiselect(context: context, entity: product));
         }
       }
       break;
   }
 }
 
-class StartMultiselect {
-  StartMultiselect({@required this.context});
+class StartProductMultiselect {
+  StartProductMultiselect({@required this.context});
 
   final BuildContext context;
 }
 
-class AddToMultiselect {
-  AddToMultiselect({@required this.context, @required this.entity});
-
-  final BuildContext context;
-  final BaseEntity entity;
-}
-
-class RemoveFromMultiselect {
-  RemoveFromMultiselect({@required this.context, @required this.entity});
+class AddToProductMultiselect {
+  AddToProductMultiselect({@required this.context, @required this.entity});
 
   final BuildContext context;
   final BaseEntity entity;
 }
 
-class ClearMultiselect {
-  ClearMultiselect({@required this.context});
+class RemoveFromProductMultiselect {
+  RemoveFromProductMultiselect({@required this.context, @required this.entity});
+
+  final BuildContext context;
+  final BaseEntity entity;
+}
+
+class ClearProductMultiselect {
+  ClearProductMultiselect({@required this.context});
 
   final BuildContext context;
 }

--- a/lib/redux/product/product_reducer.dart
+++ b/lib/redux/product/product_reducer.dart
@@ -58,10 +58,10 @@ final productListReducer = combineReducers<ListUIState>([
   TypedReducer<ListUIState, FilterProductsByState>(_filterProductsByState),
   TypedReducer<ListUIState, FilterProductsByCustom1>(_filterProductsByCustom1),
   TypedReducer<ListUIState, FilterProductsByCustom2>(_filterProductsByCustom2),
-  TypedReducer<ListUIState, StartMultiselect>(_startListMultiselect),
-  TypedReducer<ListUIState, AddToMultiselect>(_addToListMultiselect),
-  TypedReducer<ListUIState, RemoveFromMultiselect>(_removeFromListMultiselect),
-  TypedReducer<ListUIState, ClearMultiselect>(_clearListMultiselect),
+  TypedReducer<ListUIState, StartProductMultiselect>(_startListMultiselect),
+  TypedReducer<ListUIState, AddToProductMultiselect>(_addToListMultiselect),
+  TypedReducer<ListUIState, RemoveFromProductMultiselect>(_removeFromListMultiselect),
+  TypedReducer<ListUIState, ClearProductMultiselect>(_clearListMultiselect),
 ]);
 
 ListUIState _filterProductsByState(
@@ -110,24 +110,24 @@ ListUIState _sortProducts(ListUIState productListState, SortProducts action) {
 }
 
 ListUIState _startListMultiselect(
-    ListUIState productListState, StartMultiselect action) {
+    ListUIState productListState, StartProductMultiselect action) {
   return productListState.rebuild((b) => b..selectedEntities = <BaseEntity>[]);
 }
 
 ListUIState _addToListMultiselect(
-    ListUIState productListState, AddToMultiselect action) {
+    ListUIState productListState, AddToProductMultiselect action) {
   return productListState
       .rebuild((b) => b..selectedEntities.add(action.entity));
 }
 
 ListUIState _removeFromListMultiselect(
-    ListUIState productListState, RemoveFromMultiselect action) {
+    ListUIState productListState, RemoveFromProductMultiselect action) {
   return productListState
       .rebuild((b) => b..selectedEntities.remove(action.entity));
 }
 
 ListUIState _clearListMultiselect(
-    ListUIState productListState, ClearMultiselect action) {
+    ListUIState productListState, ClearProductMultiselect action) {
   return productListState.rebuild((b) => b..selectedEntities = null);
 }
 

--- a/lib/ui/app/app_scaffold.dart
+++ b/lib/ui/app/app_scaffold.dart
@@ -16,6 +16,9 @@ class AppScaffold extends StatelessWidget {
       this.appBarActions,
       this.bottomNavigationBar,
       this.floatingActionButton,
+      this.showCheckbox,
+      this.isChecked,
+      this.onCheckboxChanged,
       this.hideHamburgerButton = false});
 
   final Widget body;
@@ -24,10 +27,15 @@ class AppScaffold extends StatelessWidget {
   final Widget appBarTitle;
   final List<Widget> appBarActions;
   final bool hideHamburgerButton;
+  final bool showCheckbox;
+  final Function(bool) onCheckboxChanged;
+  final bool isChecked;
 
   @override
   Widget build(BuildContext context) {
     final store = StoreProvider.of<AppState>(context);
+    final showMenuIcon =
+        !showCheckbox && !isMobile(context) && !hideHamburgerButton;
 
     return WillPopScope(
         onWillPop: () async {
@@ -37,13 +45,19 @@ class AppScaffold extends StatelessWidget {
         child: Scaffold(
           drawer: isMobile(context) ? AppDrawerBuilder() : null,
           appBar: AppBar(
-            leading: !isMobile(context) && !hideHamburgerButton
-                ? IconButton(
-                    icon: Icon(Icons.menu),
-                    onPressed: () =>
-                        store.dispatch(UpdateSidebar(AppSidebar.menu)),
-                  )
-                : null,
+            leading: showCheckbox
+                ? Checkbox(
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    onChanged: onCheckboxChanged,
+                    activeColor: Theme.of(context).accentColor,
+                    value: isChecked)
+                : showMenuIcon
+                    ? IconButton(
+                        icon: Icon(Icons.menu),
+                        onPressed: () =>
+                            store.dispatch(UpdateSidebar(AppSidebar.menu)),
+                      )
+                    : null,
             title: appBarTitle,
             actions: appBarActions,
           ),

--- a/lib/ui/client/client_list.dart
+++ b/lib/ui/client/client_list.dart
@@ -57,41 +57,6 @@ class ClientList extends StatelessWidget {
 
                             final isInMultiselect =
                                 state.clientListState.isInMultiselect();
-
-                            //// Add header
-                            //if (index == 0 && isInMultiselect) {
-                            //  return Row(
-                            //    mainAxisAlignment: MainAxisAlignment.start,
-                            //    children: <Widget>[
-                            //      Padding(
-                            //        padding: const EdgeInsets.only(left: 20.0),
-                            //        child: Checkbox(
-                            //            materialTapTargetSize:
-                            //                MaterialTapTargetSize.shrinkWrap,
-                            //            onChanged: (value) {
-                            //              final clients = viewModel.clientList
-                            //                  .map<ClientEntity>((clientId) =>
-                            //                      viewModel.clientMap[clientId])
-                            //                  .toList();
-//
-                            //              viewModel.onEntityAction(
-                            //                  context,
-                            //                  clients,
-                            //                  EntityAction.toggleMultiselect);
-                            //            },
-                            //            activeColor:
-                            //                Theme.of(context).accentColor,
-                            //            value: state.clientListState
-                            //                    .selectedEntities.length ==
-                            //                viewModel.clientList.length),
-                            //      ),
-                            //    ],
-                            //  );
-                            //}
-//
-                            //if (isInMultiselect) {
-                            //  index--;
-                            //}
                             final userCompany = viewModel.state.userCompany;
 
                             void showDialog() => showEntityActionsDialog(

--- a/lib/ui/client/client_list.dart
+++ b/lib/ui/client/client_list.dart
@@ -58,40 +58,40 @@ class ClientList extends StatelessWidget {
                             final isInMultiselect =
                                 state.clientListState.isInMultiselect();
 
-                            // Add header
-                            if (index == 0 && isInMultiselect) {
-                              return Row(
-                                mainAxisAlignment: MainAxisAlignment.start,
-                                children: <Widget>[
-                                  Padding(
-                                    padding: const EdgeInsets.only(left: 20.0),
-                                    child: Checkbox(
-                                        materialTapTargetSize:
-                                            MaterialTapTargetSize.shrinkWrap,
-                                        onChanged: (value) {
-                                          final clients = viewModel.clientList
-                                              .map<ClientEntity>((clientId) =>
-                                                  viewModel.clientMap[clientId])
-                                              .toList();
-
-                                          viewModel.onEntityAction(
-                                              context,
-                                              clients,
-                                              EntityAction.toggleMultiselect);
-                                        },
-                                        activeColor:
-                                            Theme.of(context).accentColor,
-                                        value: state.clientListState
-                                                .selectedEntities.length ==
-                                            viewModel.clientList.length),
-                                  ),
-                                ],
-                              );
-                            }
-
-                            if (isInMultiselect) {
-                              index--;
-                            }
+                            //// Add header
+                            //if (index == 0 && isInMultiselect) {
+                            //  return Row(
+                            //    mainAxisAlignment: MainAxisAlignment.start,
+                            //    children: <Widget>[
+                            //      Padding(
+                            //        padding: const EdgeInsets.only(left: 20.0),
+                            //        child: Checkbox(
+                            //            materialTapTargetSize:
+                            //                MaterialTapTargetSize.shrinkWrap,
+                            //            onChanged: (value) {
+                            //              final clients = viewModel.clientList
+                            //                  .map<ClientEntity>((clientId) =>
+                            //                      viewModel.clientMap[clientId])
+                            //                  .toList();
+//
+                            //              viewModel.onEntityAction(
+                            //                  context,
+                            //                  clients,
+                            //                  EntityAction.toggleMultiselect);
+                            //            },
+                            //            activeColor:
+                            //                Theme.of(context).accentColor,
+                            //            value: state.clientListState
+                            //                    .selectedEntities.length ==
+                            //                viewModel.clientList.length),
+                            //      ),
+                            //    ],
+                            //  );
+                            //}
+//
+                            //if (isInMultiselect) {
+                            //  index--;
+                            //}
                             final userCompany = viewModel.state.userCompany;
 
                             void showDialog() => showEntityActionsDialog(
@@ -118,13 +118,15 @@ class ClientList extends StatelessWidget {
                                 final longPressIsSelection = store.state.uiState
                                         .longPressSelectionIsDefault ??
                                     true;
-                                if (longPressIsSelection) {
+                                if (longPressIsSelection && !isInMultiselect) {
                                   viewModel.onEntityAction(context, [client],
                                       EntityAction.toggleMultiselect);
                                 } else {
                                   showDialog();
                                 }
                               },
+                              isChecked: isInMultiselect &&
+                                  listState.isSelected(client),
                             );
                           }),
                 ),

--- a/lib/ui/client/client_list_item.dart
+++ b/lib/ui/client/client_list_item.dart
@@ -7,7 +7,7 @@ import 'package:invoiceninja_flutter/ui/app/dismissible_entity.dart';
 import 'package:invoiceninja_flutter/ui/app/entity_state_label.dart';
 import 'package:invoiceninja_flutter/utils/formatting.dart';
 
-class ClientListItem extends StatelessWidget {
+class ClientListItem extends StatefulWidget {
   const ClientListItem({
     @required this.user,
     @required this.onEntityAction,
@@ -16,6 +16,8 @@ class ClientListItem extends StatelessWidget {
     //@required this.onCheckboxChanged,
     @required this.client,
     @required this.filter,
+    this.onCheckboxChanged,
+    this.isChecked = false,
   });
 
   final UserEntity user;
@@ -26,57 +28,82 @@ class ClientListItem extends StatelessWidget {
   //final ValueChanged<bool> onCheckboxChanged;
   final ClientEntity client;
   final String filter;
+  final Function(bool) onCheckboxChanged;
+  final bool isChecked;
 
   static final clientItemKey = (int id) => Key('__client_item_${id}__');
 
+  @override
+  _ClientListItemState createState() => _ClientListItemState();
+}
+
+class _ClientListItemState extends State<ClientListItem>
+    with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     //var localization = AppLocalization.of(context);
     final store = StoreProvider.of<AppState>(context);
     final uiState = store.state.uiState;
     final clientUIState = uiState.clientUIState;
-    final filterMatch = filter != null && filter.isNotEmpty
-        ? client.matchesFilterValue(filter)
+    final filterMatch = widget.filter != null && widget.filter.isNotEmpty
+        ? widget.client.matchesFilterValue(widget.filter)
         : null;
     final listUIState = clientUIState.listUIState;
     final isInMultiselect = listUIState.isInMultiselect();
+    final showCheckbox = widget.onCheckboxChanged != null || isInMultiselect;
+
+    if (isInMultiselect) {
+      _multiselectCheckboxAnimController.forward();
+    } else {
+      _multiselectCheckboxAnimController.animateBack(0.0);
+    }
 
     return DismissibleEntity(
-      isSelected: client.id ==
+      isSelected: widget.client.id ==
           (uiState.isEditing
               ? clientUIState.editing.id
               : clientUIState.selectedId),
       userCompany: store.state.userCompany,
-      onEntityAction: onEntityAction,
-      entity: client,
+      onEntityAction: widget.onEntityAction,
+      entity: widget.client,
       //entityKey: clientItemKey,
       child: ListTile(
         onTap: isInMultiselect
-            ? () => onEntityAction(EntityAction.toggleMultiselect)
-            : onTap,
-        onLongPress: onLongPress,
-        title: Row(
-          children: <Widget>[
-            if (isInMultiselect)
-              IgnorePointer(
-                  child: Padding(
-                padding: const EdgeInsets.only(right: 12.0),
-                child: Checkbox(
+            ? () => widget.onEntityAction(EntityAction.toggleMultiselect)
+            : widget.onTap,
+        onLongPress: widget.onLongPress,
+        leading: showCheckbox
+            ? FadeTransition(
+                opacity: _multiselectCheckboxAnim,
+                child: IgnorePointer(
+                  ignoring: listUIState.isInMultiselect(),
+                  child: Checkbox(
+                    value: widget.isChecked,
                     materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    value: listUIState.isSelected(client),
-                    onChanged: null),
-              )),
-            Expanded(
-              child: Text(
-                client.displayName,
-                style: Theme.of(context).textTheme.title,
+                    onChanged: (value) => widget.onCheckboxChanged(value),
+                    activeColor: Theme.of(context).accentColor,
+                  ),
+                ),
+              )
+            : null,
+        title: Container(
+          width: MediaQuery.of(context).size.width,
+          child: Row(
+            children: <Widget>[
+              Expanded(
+                child: Text(
+                  widget.client.displayName,
+                  style: Theme.of(context).textTheme.title,
+                ),
               ),
-            ),
-            Text(formatNumber(client.balance, context, clientId: client.id),
-                style: Theme.of(context).textTheme.title),
-          ],
+              Text(
+                  formatNumber(widget.client.balance, context,
+                      clientId: widget.client.id),
+                  style: Theme.of(context).textTheme.title),
+            ],
+          ),
         ),
-        subtitle: (filterMatch == null && client.isActive)
+        subtitle: (filterMatch == null && widget.client.isActive)
             ? null
             : Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
@@ -88,10 +115,28 @@ class ClientListItem extends StatelessWidget {
                           overflow: TextOverflow.ellipsis,
                         )
                       : SizedBox(),
-                  EntityStateLabel(client),
+                  EntityStateLabel(widget.client),
                 ],
               ),
       ),
     );
+  }
+
+  Animation _multiselectCheckboxAnim;
+  AnimationController _multiselectCheckboxAnimController;
+
+  @override
+  void initState() {
+    super.initState();
+    _multiselectCheckboxAnimController =
+        AnimationController(vsync: this, duration: Duration(milliseconds: 500));
+    _multiselectCheckboxAnim = Tween<double>(begin: 0.0, end: 1.0)
+        .animate(_multiselectCheckboxAnimController);
+  }
+
+  @override
+  void dispose() {
+    _multiselectCheckboxAnimController.dispose();
+    super.dispose();
   }
 }

--- a/lib/ui/client/client_screen.dart
+++ b/lib/ui/client/client_screen.dart
@@ -68,7 +68,7 @@ class ClientScreen extends StatelessWidget {
               localization.cancel,
               style: TextStyle(color: Colors.white),
             ),
-            onPressed: () => store.dispatch(ClearMultiselect(context: context)),
+            onPressed: () => store.dispatch(ClearClientMultiselect(context: context)),
           ),
         if (viewModel.isInMultiselect)
           FlatButton(
@@ -87,7 +87,7 @@ class ClientScreen extends StatelessWidget {
                         context: context,
                         onEntityAction: viewModel.onEntityAction,
                         multiselect: true);
-                    store.dispatch(ClearMultiselect(context: context));
+                    store.dispatch(ClearClientMultiselect(context: context));
                   },
           ),
       ],

--- a/lib/ui/client/client_screen.dart
+++ b/lib/ui/client/client_screen.dart
@@ -51,27 +51,30 @@ class ClientScreen extends StatelessWidget {
           FlatButton(
             key: key,
             child: Text(
-              localization.done,
-              style: TextStyle(color: Colors.white),
-            ),
-            onPressed: () async {
-              await showEntityActionsDialog(
-                  entities: state.clientListState.selectedEntities,
-                  userCompany: userCompany,
-                  context: context,
-                  onEntityAction: viewModel.onEntityAction,
-                  multiselect: true);
-              store.dispatch(ClearMultiselect(context: context));
-            },
-          ),
-        if (viewModel.isInMultiselect)
-          FlatButton(
-            key: key,
-            child: Text(
               localization.cancel,
               style: TextStyle(color: Colors.white),
             ),
             onPressed: () => store.dispatch(ClearMultiselect(context: context)),
+          ),
+        if (viewModel.isInMultiselect)
+          FlatButton(
+            key: key,
+            textColor: Colors.white,
+            disabledTextColor: Colors.white54,
+            child: Text(
+              localization.done,
+            ),
+            onPressed: state.clientListState.selectedEntities.isEmpty
+                ? null
+                : () async {
+                    await showEntityActionsDialog(
+                        entities: state.clientListState.selectedEntities,
+                        userCompany: userCompany,
+                        context: context,
+                        onEntityAction: viewModel.onEntityAction,
+                        multiselect: true);
+                    store.dispatch(ClearMultiselect(context: context));
+                  },
           ),
       ],
       body: ClientListBuilder(),

--- a/lib/ui/client/client_screen.dart
+++ b/lib/ui/client/client_screen.dart
@@ -30,8 +30,22 @@ class ClientScreen extends StatelessWidget {
     final company = state.selectedCompany;
     final userCompany = state.userCompany;
     final localization = AppLocalization.of(context);
+    final listUIState = state.uiState.clientUIState.listUIState;
+    final isInMultiselect = listUIState.isInMultiselect();
 
     return AppScaffold(
+      isChecked: isInMultiselect &&
+          listUIState.selectedEntities.length == viewModel.clientList.length,
+      showCheckbox: isInMultiselect,
+      onCheckboxChanged: (value) {
+        final clients = viewModel.clientList
+            .map<ClientEntity>((clientId) => viewModel.clientMap[clientId])
+            .where((client) => value != listUIState.isSelected(client))
+            .toList();
+
+        viewModel.onEntityAction(
+            context, clients, EntityAction.toggleMultiselect);
+      },
       appBarTitle: ListFilter(
         key: ValueKey(state.clientListState.filterClearedAt),
         entityType: EntityType.client,

--- a/lib/ui/client/client_screen_vm.dart
+++ b/lib/ui/client/client_screen_vm.dart
@@ -1,3 +1,4 @@
+import 'package:built_collection/built_collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
@@ -5,6 +6,7 @@ import 'package:flutter_redux/flutter_redux.dart';
 import 'package:invoiceninja_flutter/data/models/models.dart';
 import 'package:invoiceninja_flutter/redux/app/app_state.dart';
 import 'package:invoiceninja_flutter/redux/client/client_actions.dart';
+import 'package:invoiceninja_flutter/redux/client/client_selectors.dart';
 import 'package:redux/redux.dart';
 
 import 'client_screen.dart';
@@ -29,18 +31,25 @@ class ClientScreenBuilder extends StatelessWidget {
 class ClientScreenVM {
   ClientScreenVM({
     @required this.isInMultiselect,
+    @required this.clientList,
     @required this.userCompany,
     @required this.onEntityAction,
+    @required this.clientMap,
   });
 
   final bool isInMultiselect;
   final UserCompanyEntity userCompany;
+  final List<String> clientList;
   final Function(BuildContext, List<ClientEntity>, EntityAction) onEntityAction;
+  final BuiltMap<String, ClientEntity> clientMap;
 
   static ClientScreenVM fromStore(Store<AppState> store) {
     final state = store.state;
 
     return ClientScreenVM(
+      clientMap: state.clientState.map,
+      clientList: memoizedFilteredClientList(state.clientState.map,
+          state.clientState.list, state.groupState.map, state.clientListState),
       userCompany: state.userCompany,
       isInMultiselect: state.clientListState.isInMultiselect(),
       onEntityAction: (BuildContext context, List<BaseEntity> clients,

--- a/lib/ui/product/product_list.dart
+++ b/lib/ui/product/product_list.dart
@@ -43,36 +43,6 @@ class ProductList extends StatelessWidget {
               ? viewModel.productList.length //+ 1
               : viewModel.productList.length,
           itemBuilder: (BuildContext context, index) {
-            // Add header
-            //if (index == 0 && isInMultiselect) {
-            //  return Row(
-            //    mainAxisAlignment: MainAxisAlignment.start,
-            //    children: <Widget>[
-            //      Padding(
-            //        padding: const EdgeInsets.only(left: 20.0),
-            //        child: Checkbox(
-            //            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-            //            onChanged: (value) {
-            //              final products = viewModel.productList
-            //                  .map<ProductEntity>((productId) =>
-            //                      viewModel.productMap[productId])
-            //                  .toList();
-//
-            //              viewModel.onEntityAction(context, products,
-            //                  EntityAction.toggleMultiselect);
-            //            },
-            //            activeColor: Theme.of(context).accentColor,
-            //            value: listUIState.selectedEntities.length ==
-            //                viewModel.productList.length),
-            //      ),
-            //    ],
-            //  );
-            //}
-//
-            //if (isInMultiselect) {
-            //  index--;
-            //}
-
             final productId = viewModel.productList[index];
             final product = viewModel.productMap[productId];
 

--- a/lib/ui/product/product_list.dart
+++ b/lib/ui/product/product_list.dart
@@ -40,38 +40,38 @@ class ProductList extends StatelessWidget {
       child: ListView.separated(
           separatorBuilder: (context, index) => ListDivider(),
           itemCount: isInMultiselect
-              ? viewModel.productList.length + 1
+              ? viewModel.productList.length //+ 1
               : viewModel.productList.length,
           itemBuilder: (BuildContext context, index) {
             // Add header
-            if (index == 0 && isInMultiselect) {
-              return Row(
-                mainAxisAlignment: MainAxisAlignment.start,
-                children: <Widget>[
-                  Padding(
-                    padding: const EdgeInsets.only(left: 20.0),
-                    child: Checkbox(
-                        materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                        onChanged: (value) {
-                          final products = viewModel.productList
-                              .map<ProductEntity>((productId) =>
-                                  viewModel.productMap[productId])
-                              .toList();
-
-                          viewModel.onEntityAction(context, products,
-                              EntityAction.toggleMultiselect);
-                        },
-                        activeColor: Theme.of(context).accentColor,
-                        value: listUIState.selectedEntities.length ==
-                            viewModel.productList.length),
-                  ),
-                ],
-              );
-            }
-
-            if (isInMultiselect) {
-              index--;
-            }
+            //if (index == 0 && isInMultiselect) {
+            //  return Row(
+            //    mainAxisAlignment: MainAxisAlignment.start,
+            //    children: <Widget>[
+            //      Padding(
+            //        padding: const EdgeInsets.only(left: 20.0),
+            //        child: Checkbox(
+            //            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            //            onChanged: (value) {
+            //              final products = viewModel.productList
+            //                  .map<ProductEntity>((productId) =>
+            //                      viewModel.productMap[productId])
+            //                  .toList();
+//
+            //              viewModel.onEntityAction(context, products,
+            //                  EntityAction.toggleMultiselect);
+            //            },
+            //            activeColor: Theme.of(context).accentColor,
+            //            value: listUIState.selectedEntities.length ==
+            //                viewModel.productList.length),
+            //      ),
+            //    ],
+            //  );
+            //}
+//
+            //if (isInMultiselect) {
+            //  index--;
+            //}
 
             final productId = viewModel.productList[index];
             final product = viewModel.productMap[productId];
@@ -97,7 +97,7 @@ class ProductList extends StatelessWidget {
               onLongPress: () async {
                 final longPressIsSelection =
                     store.state.uiState.longPressSelectionIsDefault ?? true;
-                if (longPressIsSelection) {
+                if (longPressIsSelection && !isInMultiselect) {
                   viewModel.onEntityAction(
                       context, [product], EntityAction.toggleMultiselect);
                 } else {

--- a/lib/ui/product/product_screen.dart
+++ b/lib/ui/product/product_screen.dart
@@ -50,29 +50,32 @@ class ProductScreen extends StatelessWidget {
           FlatButton(
             key: key,
             child: Text(
-              localization.done,
-              style: TextStyle(color: Colors.white),
-            ),
-            onPressed: () async {
-              await showEntityActionsDialog(
-                  entities: state.productListState.selectedEntities,
-                  userCompany: userCompany,
-                  context: context,
-                  onEntityAction: viewModel.onEntityAction,
-                  multiselect: true);
-              store.dispatch(ClearMultiselect(context: context));
-            },
-          ),
-        if (viewModel.isInMultiselect)
-          FlatButton(
-            key: key,
-            child: Text(
               localization.cancel,
               style: TextStyle(color: Colors.white),
             ),
             onPressed: () {
               store.dispatch(ClearMultiselect(context: context));
             },
+          ),
+        if (viewModel.isInMultiselect)
+          FlatButton(
+            key: key,
+            textColor: Colors.white,
+            disabledTextColor: Colors.white54,
+            child: Text(
+              localization.done,
+            ),
+            onPressed: state.productListState.selectedEntities.isEmpty
+                ? null
+                : () async {
+                    await showEntityActionsDialog(
+                        entities: state.productListState.selectedEntities,
+                        userCompany: userCompany,
+                        context: context,
+                        onEntityAction: viewModel.onEntityAction,
+                        multiselect: true);
+                    store.dispatch(ClearMultiselect(context: context));
+                  },
           ),
       ],
       body: ProductListBuilder(),

--- a/lib/ui/product/product_screen.dart
+++ b/lib/ui/product/product_screen.dart
@@ -68,7 +68,7 @@ class ProductScreen extends StatelessWidget {
               style: TextStyle(color: Colors.white),
             ),
             onPressed: () {
-              store.dispatch(ClearMultiselect(context: context));
+              store.dispatch(ClearProductMultiselect(context: context));
             },
           ),
         if (viewModel.isInMultiselect)
@@ -88,7 +88,7 @@ class ProductScreen extends StatelessWidget {
                         context: context,
                         onEntityAction: viewModel.onEntityAction,
                         multiselect: true);
-                    store.dispatch(ClearMultiselect(context: context));
+                    store.dispatch(ClearProductMultiselect(context: context));
                   },
           ),
       ],

--- a/lib/ui/product/product_screen.dart
+++ b/lib/ui/product/product_screen.dart
@@ -26,11 +26,25 @@ class ProductScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final store = StoreProvider.of<AppState>(context);
     final state = store.state;
+    final listUIState = state.uiState.productUIState.listUIState;
     final company = state.selectedCompany;
     final userCompany = state.userCompany;
     final localization = AppLocalization.of(context);
+    final isInMultiselect = listUIState.isInMultiselect();
 
     return AppScaffold(
+      isChecked: isInMultiselect &&
+          listUIState.selectedEntities.length == viewModel.productList.length,
+      showCheckbox: isInMultiselect,
+      onCheckboxChanged: (value) {
+        final products = viewModel.productList
+            .map<ProductEntity>((productId) => viewModel.productMap[productId])
+            .where((product) => value != listUIState.isSelected(product))
+            .toList();
+
+        viewModel.onEntityAction(
+            context, products, EntityAction.toggleMultiselect);
+      },
       appBarTitle: ListFilter(
         key: ValueKey(store.state.productListState.filterClearedAt),
         entityType: EntityType.product,

--- a/lib/ui/product/product_screen_vm.dart
+++ b/lib/ui/product/product_screen_vm.dart
@@ -1,3 +1,4 @@
+import 'package:built_collection/built_collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
@@ -5,6 +6,7 @@ import 'package:flutter_redux/flutter_redux.dart';
 import 'package:invoiceninja_flutter/data/models/models.dart';
 import 'package:invoiceninja_flutter/redux/app/app_state.dart';
 import 'package:invoiceninja_flutter/redux/product/product_actions.dart';
+import 'package:invoiceninja_flutter/redux/product/product_selectors.dart';
 import 'package:redux/redux.dart';
 
 import 'product_screen.dart';
@@ -29,18 +31,25 @@ class ProductScreenBuilder extends StatelessWidget {
 class ProductScreenVM {
   ProductScreenVM({
     @required this.isInMultiselect,
+    @required this.productList,
     @required this.userCompany,
     @required this.onEntityAction,
+    @required this.productMap,
   });
 
   final bool isInMultiselect;
   final UserCompanyEntity userCompany;
+  final List<String> productList;
   final Function(BuildContext, List<BaseEntity>, EntityAction) onEntityAction;
+  final BuiltMap<String, ProductEntity> productMap;
 
   static ProductScreenVM fromStore(Store<AppState> store) {
     final state = store.state;
 
     return ProductScreenVM(
+      productMap: state.productState.map,
+      productList: memoizedFilteredProductList(state.productState.map,
+          state.productState.list, state.productListState),
       userCompany: state.userCompany,
       isInMultiselect: state.productListState.isInMultiselect(),
       onEntityAction: (BuildContext context, List<BaseEntity> products,


### PR DESCRIPTION
- Removed blank space in list items and added Fade Animation
- Moved "Check All" checkbox to AppBar
- "Check All" checkbox now behaves as expected
- If the user is in checkbox mode and then long presses an item it now shows the entity action popup rather than check/uncheck the record.
- "Done" button is now only active if at least one entity is selected
- "Done"/"Cancel" buttons order switched
- Renamed multiselect actions to include the module's name